### PR TITLE
Too fast to learn work stroke. Change delay 0.5 to 0.25 in js/jquery.strokeWords.js

### DIFF
--- a/js/jquery.strokeWords.js
+++ b/js/jquery.strokeWords.js
@@ -663,7 +663,7 @@
         },
         updatesPerStep: 10,
         delays: {
-          stroke: 0.25,
+          stroke: 0.5,
           word: 0.5
         },
         progress: null,


### PR DESCRIPTION
萌典松收到小朋友的需求，筆畫速度過快來不及學習，先放慢為 delay 0.5 （原 0.25）